### PR TITLE
Enabling the plugin for all IntelliJ platform-based products

### DIFF
--- a/plugin.idea/META-INF/plugin.xml
+++ b/plugin.idea/META-INF/plugin.xml
@@ -53,6 +53,8 @@
     <!-- uncomment to enable plugin in all products
     <depends>com.intellij.modules.lang</depends>
     -->
+    <depends>com.intellij.modules.lang</depends>
+
     <depends>Git4Idea</depends>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Hey, I was able to install the plugin for WebStorm (11.0.1), but it was not loaded during startup. The reason is that the plugin was not marked as compatible with broader range of products based on IntelliJ platform (https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products). Please check my PR with the fix.