### PR TITLE
Updated FindBugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Gradle stuff
+**/hs_err_pid*.log
 .gradle
 build
+**/.idea
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ subprojects {
     dependencies {
         ideaSdkLibs fileTree(dir: "$ideaSdk", include: '*.jar')
         git4ideaLibs fileTree(dir: "$git4idea", include: '*.jar')
-        codeAnalysisLibs 'com.google.code.findbugs:annotations:3.0.0'
+        codeAnalysisLibs 'com.google.code.findbugs:annotations:3.0.1'
 
         compile group: 'com.microsoft.vss.sdk.httpclient', name: 'vss-http-client', version: '0.4.2-SNAPSHOT'
         compile group: 'com.microsoft.tf', name: 'aad-pat-generator', version: '1.0.1'
@@ -228,6 +228,6 @@ subprojects {
      * Static code analysis tools
      */
     findbugs {
-      toolVersion = "2.0.3"
+      toolVersion = "3.0.1"
     }
 }


### PR DESCRIPTION
The FindBugs version referenced was not handling Java8 class file formats. Version `3.0.1` does. Also updated a bit the .gitignore file.