### PR TITLE
Discoutinue usage of global Personal Access Tokens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ subprojects {
         /* Task 454223: anchor JNA dependency to version 3.4.0 to match Android Studio 1.4 and IntelliJ IDEA 14 */
         compile group: 'net.java.dev.jna', name: 'jna', version: '3.4.0'
 
-        compile (group: 'com.microsoft.alm', name: 'auth-providers', version: '0.5.0') {
+        compile (group: 'com.microsoft.alm', name: 'auth-core', version: '0.6.2') {
             /* Exclude default JNA dependency (would be version 4.2.1 as of this writing) */
             exclude group: 'net.java.dev.jna', module: 'jna'
             exclude group: 'net.java.dev.jna', module: 'jna-platform'

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/common/ui/checkout/VsoCheckoutPageModel.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/common/ui/checkout/VsoCheckoutPageModel.java
@@ -48,7 +48,8 @@ public class VsoCheckoutPageModel extends CheckoutPageModelImpl {
                 ServerContextLookupOperation.ContextScope.REPOSITORY :
                 ServerContextLookupOperation.ContextScope.PROJECT;
 
-        if (autoLoad && authenticationProvider.isAuthenticated()) {
+        final String serverUri = LookupHelper.getVsspsUrlFromDisplayName(this.getServerName());
+        if (autoLoad && authenticationProvider.isAuthenticated(serverUri)) {
             logger.info("Loading contexts in constructor");
             LookupHelper.loadVsoContexts(this, this,
                     authenticationProvider, getRepositoryProvider(),
@@ -60,14 +61,16 @@ public class VsoCheckoutPageModel extends CheckoutPageModelImpl {
 
     @Override
     protected AuthenticationInfo getAuthenticationInfo() {
-        return authenticationProvider.getAuthenticationInfo();
+        return authenticationProvider.getAuthenticationInfo(this.getServerName());
     }
 
     @Override
     public void signOut() {
         logger.info("signOut called");
+        String serverUri = LookupHelper.getVsspsUrlFromDisplayName(this.getServerName());
+        authenticationProvider.clearAuthenticationDetails(serverUri);
+
         super.signOut();
-        authenticationProvider.clearAuthenticationDetails();
     }
 
     @Override

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/git/ui/vcsimport/TfsImportPageModel.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/git/ui/vcsimport/TfsImportPageModel.java
@@ -30,9 +30,9 @@ public class TfsImportPageModel extends ImportPageModelImpl {
 
         if (!UrlHelper.isTeamServicesUrl(getServerName())) {
             authenticationProvider = TfsAuthenticationProvider.getInstance();
-            if (authenticationProvider.isAuthenticated()) {
+            if (authenticationProvider.isAuthenticated(this.getServerName())) {
                 logger.info("TFS auth info already found so reusing that for loading repos");
-                final AuthenticationInfo info = authenticationProvider.getAuthenticationInfo();
+                final AuthenticationInfo info = authenticationProvider.getAuthenticationInfo(this.getServerName());
                 setServerNameInternal(info.getServerUri());
                 LookupHelper.loadTfsContexts(this, this,
                         authenticationProvider, getTeamProjectProvider(),
@@ -40,9 +40,9 @@ public class TfsImportPageModel extends ImportPageModelImpl {
             }
         } else {
             authenticationProvider = VsoAuthenticationProvider.getInstance();
-            if (authenticationProvider.isAuthenticated()) {
+            if (authenticationProvider.isAuthenticated(this.getServerName())) {
                 logger.info("VSTS auth info already found so reusing that for loading repos");
-                setServerNameInternal((authenticationProvider.getAuthenticationInfo().getServerUri()));
+                setServerNameInternal((authenticationProvider.getAuthenticationInfo(this.getServerName()).getServerUri()));
                 LookupHelper.loadVsoContexts(this, this,
                         authenticationProvider, getTeamProjectProvider(),
                         ServerContextLookupOperation.ContextScope.PROJECT);
@@ -52,13 +52,13 @@ public class TfsImportPageModel extends ImportPageModelImpl {
 
     @Override
     protected AuthenticationInfo getAuthenticationInfo() {
-        return authenticationProvider.getAuthenticationInfo();
+        return authenticationProvider.getAuthenticationInfo(this.getServerName());
     }
 
     @Override
     public void signOut() {
         super.signOut();
-        authenticationProvider.clearAuthenticationDetails();
+        authenticationProvider.clearAuthenticationDetails(this.getServerName());
     }
 
     @Override

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/git/ui/vcsimport/VsoImportPageModel.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/git/ui/vcsimport/VsoImportPageModel.java
@@ -29,7 +29,8 @@ public class VsoImportPageModel extends ImportPageModelImpl {
         setConnected(false);
         setAuthenticating(false);
 
-        if (autoLoad && authenticationProvider.isAuthenticated()) {
+        final String serverName = LookupHelper.getVsspsUrlFromDisplayName(this.getServerName());
+        if (autoLoad && authenticationProvider.isAuthenticated(serverName)) {
             // Load the projects from all accounts into the list
             LookupHelper.loadVsoContexts(this, this,
                     authenticationProvider, getTeamProjectProvider(),
@@ -38,13 +39,13 @@ public class VsoImportPageModel extends ImportPageModelImpl {
     }
 
     protected AuthenticationInfo getAuthenticationInfo() {
-        return authenticationProvider.getAuthenticationInfo();
+        return authenticationProvider.getAuthenticationInfo(this.getServerName());
     }
 
     @Override
     public void signOut() {
         super.signOut();
-        authenticationProvider.clearAuthenticationDetails();
+        authenticationProvider.clearAuthenticationDetails(this.getServerName());
     }
 
     @Override

--- a/plugin.idea/test/com/microsoft/alm/plugin/idea/common/ui/common/LookupHelperTests.java
+++ b/plugin.idea/test/com/microsoft/alm/plugin/idea/common/ui/common/LookupHelperTests.java
@@ -110,8 +110,8 @@ public class LookupHelperTests extends IdeaAbstractTest {
         when(loginPageModel.getServerName()).thenReturn(serverUrl);
         final ServerContextLookupPageModel lookupPageModel = Mockito.mock(ServerContextLookupPageModel.class);
         final AuthenticationProvider authenticationProvider = Mockito.mock(AuthenticationProvider.class);
-        when(authenticationProvider.isAuthenticated()).thenReturn(true);
-        when(authenticationProvider.getAuthenticationInfo()).thenReturn(authInfo);
+        when(authenticationProvider.isAuthenticated(serverUrl)).thenReturn(true);
+        when(authenticationProvider.getAuthenticationInfo(serverUrl)).thenReturn(authInfo);
         final ServerContextLookupListener lookupListener = Mockito.mock(ServerContextLookupListener.class);
 
         LookupHelper.authenticateAndLoadTfsContexts(loginPageModel, lookupPageModel,
@@ -131,8 +131,8 @@ public class LookupHelperTests extends IdeaAbstractTest {
         when(loginPageModel.getServerName()).thenReturn(serverUrl);
         final ServerContextLookupPageModel lookupPageModel = Mockito.mock(ServerContextLookupPageModel.class);
         final AuthenticationProvider authenticationProvider = Mockito.mock(AuthenticationProvider.class);
-        when(authenticationProvider.isAuthenticated()).thenReturn(false);
-        when(authenticationProvider.getAuthenticationInfo()).thenReturn(authInfo);
+        when(authenticationProvider.isAuthenticated(serverUrl)).thenReturn(false);
+        when(authenticationProvider.getAuthenticationInfo(serverUrl)).thenReturn(authInfo);
         doNothing().when(authenticationProvider).authenticateAsync(Matchers.anyString(), Matchers.any(AuthenticationListener.class));
         final ServerContextLookupListener lookupListener = Mockito.mock(ServerContextLookupListener.class);
 
@@ -160,8 +160,8 @@ public class LookupHelperTests extends IdeaAbstractTest {
         when(loginPageModel.getServerName()).thenReturn(serverUrl);
         final ServerContextLookupPageModel lookupPageModel = Mockito.mock(ServerContextLookupPageModel.class);
         final AuthenticationProvider authenticationProvider = Mockito.mock(AuthenticationProvider.class);
-        when(authenticationProvider.isAuthenticated()).thenReturn(false);
-        when(authenticationProvider.getAuthenticationInfo()).thenReturn(authInfo);
+        when(authenticationProvider.isAuthenticated(serverUrl)).thenReturn(false);
+        when(authenticationProvider.getAuthenticationInfo(serverUrl)).thenReturn(authInfo);
         doNothing().when(authenticationProvider).authenticateAsync(Matchers.anyString(), Matchers.any(AuthenticationListener.class));
         final ServerContextLookupListener lookupListener = Mockito.mock(ServerContextLookupListener.class);
 
@@ -189,8 +189,8 @@ public class LookupHelperTests extends IdeaAbstractTest {
         when(loginPageModel.getServerName()).thenReturn(serverUrl);
         final ServerContextLookupPageModel lookupPageModel = Mockito.mock(ServerContextLookupPageModel.class);
         final AuthenticationProvider authenticationProvider = Mockito.mock(AuthenticationProvider.class);
-        when(authenticationProvider.isAuthenticated()).thenReturn(false);
-        when(authenticationProvider.getAuthenticationInfo()).thenReturn(authInfo);
+        when(authenticationProvider.isAuthenticated(serverUrl)).thenReturn(false);
+        when(authenticationProvider.getAuthenticationInfo(serverUrl)).thenReturn(authInfo);
         doNothing().when(authenticationProvider).authenticateAsync(Matchers.anyString(), Matchers.any(AuthenticationListener.class));
         final ServerContextLookupListener lookupListener = Mockito.mock(ServerContextLookupListener.class);
 
@@ -218,8 +218,8 @@ public class LookupHelperTests extends IdeaAbstractTest {
         when(loginPageModel.getServerName()).thenReturn(serverUrl);
         final ServerContextLookupPageModel lookupPageModel = Mockito.mock(ServerContextLookupPageModel.class);
         final AuthenticationProvider authenticationProvider = Mockito.mock(AuthenticationProvider.class);
-        when(authenticationProvider.isAuthenticated()).thenReturn(true);
-        when(authenticationProvider.getAuthenticationInfo()).thenReturn(authInfo);
+        when(authenticationProvider.isAuthenticated(serverUrl)).thenReturn(true);
+        when(authenticationProvider.getAuthenticationInfo(serverUrl)).thenReturn(authInfo);
         final ServerContextLookupListener lookupListener = Mockito.mock(ServerContextLookupListener.class);
 
         LookupHelper.authenticateAndLoadVsoContexts(loginPageModel, lookupPageModel,
@@ -239,8 +239,8 @@ public class LookupHelperTests extends IdeaAbstractTest {
         when(loginPageModel.getServerName()).thenReturn(serverUrl);
         final ServerContextLookupPageModel lookupPageModel = Mockito.mock(ServerContextLookupPageModel.class);
         final AuthenticationProvider authenticationProvider = Mockito.mock(AuthenticationProvider.class);
-        when(authenticationProvider.isAuthenticated()).thenReturn(true);
-        when(authenticationProvider.getAuthenticationInfo()).thenReturn(authInfo);
+        when(authenticationProvider.isAuthenticated(serverUrl)).thenReturn(true);
+        when(authenticationProvider.getAuthenticationInfo(serverUrl)).thenReturn(authInfo);
         final ServerContextLookupListener lookupListener = Mockito.mock(ServerContextLookupListener.class);
 
         LookupHelper.authenticateAndLoadVsoContexts(loginPageModel, lookupPageModel,
@@ -261,8 +261,8 @@ public class LookupHelperTests extends IdeaAbstractTest {
         when(loginPageModel.getServerName()).thenReturn(serverUrl);
         final ServerContextLookupPageModel lookupPageModel = Mockito.mock(ServerContextLookupPageModel.class);
         final AuthenticationProvider authenticationProvider = Mockito.mock(AuthenticationProvider.class);
-        when(authenticationProvider.isAuthenticated()).thenReturn(false);
-        when(authenticationProvider.getAuthenticationInfo()).thenReturn(authInfo);
+        when(authenticationProvider.isAuthenticated(serverUrl)).thenReturn(false);
+        when(authenticationProvider.getAuthenticationInfo(serverUrl)).thenReturn(authInfo);
         doNothing().when(authenticationProvider).authenticateAsync(Matchers.anyString(), Matchers.any(AuthenticationListener.class));
         final ServerContextLookupListener lookupListener = Mockito.mock(ServerContextLookupListener.class);
 
@@ -290,8 +290,8 @@ public class LookupHelperTests extends IdeaAbstractTest {
         when(loginPageModel.getServerName()).thenReturn(serverUrl);
         final ServerContextLookupPageModel lookupPageModel = Mockito.mock(ServerContextLookupPageModel.class);
         final AuthenticationProvider authenticationProvider = Mockito.mock(AuthenticationProvider.class);
-        when(authenticationProvider.isAuthenticated()).thenReturn(false);
-        when(authenticationProvider.getAuthenticationInfo()).thenReturn(authInfo);
+        when(authenticationProvider.isAuthenticated(serverUrl)).thenReturn(false);
+        when(authenticationProvider.getAuthenticationInfo(serverUrl)).thenReturn(authInfo);
         doNothing().when(authenticationProvider).authenticateAsync(Matchers.anyString(), Matchers.any(AuthenticationListener.class));
         final ServerContextLookupListener lookupListener = Mockito.mock(ServerContextLookupListener.class);
 
@@ -319,8 +319,8 @@ public class LookupHelperTests extends IdeaAbstractTest {
         when(loginPageModel.getServerName()).thenReturn(serverUrl);
         final ServerContextLookupPageModel lookupPageModel = Mockito.mock(ServerContextLookupPageModel.class);
         final AuthenticationProvider authenticationProvider = Mockito.mock(AuthenticationProvider.class);
-        when(authenticationProvider.isAuthenticated()).thenReturn(false);
-        when(authenticationProvider.getAuthenticationInfo()).thenReturn(authInfo);
+        when(authenticationProvider.isAuthenticated(serverUrl)).thenReturn(false);
+        when(authenticationProvider.getAuthenticationInfo(serverUrl)).thenReturn(authInfo);
         doNothing().when(authenticationProvider).authenticateAsync(Matchers.anyString(), Matchers.any(AuthenticationListener.class));
         final ServerContextLookupListener lookupListener = Mockito.mock(ServerContextLookupListener.class);
 

--- a/plugin/src/com/microsoft/alm/plugin/authentication/AuthHelper.java
+++ b/plugin/src/com/microsoft/alm/plugin/authentication/AuthHelper.java
@@ -31,12 +31,16 @@ public class AuthHelper {
      */
     private static final String TOKEN_DESCRIPTION_FORMATTER = "VSTS IntelliJ Plugin: %s from: %s on: %s";
 
-    public static AuthenticationInfo createAuthenticationInfo(final String serverUri, final Credentials credentials) {
+    public static AuthenticationInfo createAuthenticationInfo(final String serverUri,
+                                                              final Credentials credentials,
+                                                              AuthenticationInfo.CredsType type) {
         return new AuthenticationInfo(
                 credentials.getUserPrincipal().getName(),
                 credentials.getPassword(),
                 serverUri,
-                credentials.getUserPrincipal().getName()
+                credentials.getUserPrincipal().getName(),
+                type,
+                null
         );
     }
 

--- a/plugin/src/com/microsoft/alm/plugin/authentication/AuthenticationInfo.java
+++ b/plugin/src/com/microsoft/alm/plugin/authentication/AuthenticationInfo.java
@@ -7,6 +7,12 @@ package com.microsoft.alm.plugin.authentication;
  * Immutable
  */
 public class AuthenticationInfo {
+
+    public enum CredsType {
+        AccessToken,
+        PersonalAccessToken,
+        NTLM
+    }
     // If we all use this constant, it provides future type safely if we ever decided to change NONE to a
     // typed variable instead of 'null'
     public static AuthenticationInfo NONE = null;
@@ -15,6 +21,8 @@ public class AuthenticationInfo {
     private final String password;
     private final String serverUri;
     private final String userNameForDisplay;
+    private final String refreshToken;
+    private final CredsType type;
 
     /**
      * Empty constructor for JSON deserialization only.  Do not use this otherwise (which is why it is marked deprecated).
@@ -22,17 +30,28 @@ public class AuthenticationInfo {
      * @deprecated
      */
     public AuthenticationInfo() {
-        userName = null;
-        password = null;
-        serverUri = null;
-        userNameForDisplay = null;
+        this(null, null, null, null, null, null);
     }
 
-    public AuthenticationInfo(final String userName, final String password, final String serverUri, final String userNameForDisplay) {
+    public AuthenticationInfo(final String userName,
+                              final String password,
+                              final String serverUri,
+                              final String userNameForDisplay) {
+        this(userName, password, serverUri, userNameForDisplay, null, null);
+    }
+
+    public AuthenticationInfo(final String userName,
+                              final String password,
+                              final String serverUri,
+                              final String userNameForDisplay,
+                              final CredsType type,
+                              final String refreshToken) {
         this.userName = userName;
         this.password = password;
         this.serverUri = serverUri;
         this.userNameForDisplay = userNameForDisplay;
+        this.type = type;
+        this.refreshToken = refreshToken;
     }
 
     public String getServerUri() {
@@ -51,4 +70,11 @@ public class AuthenticationInfo {
         return userNameForDisplay;
     }
 
+    public CredsType getType() {
+        return type;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
 }

--- a/plugin/src/com/microsoft/alm/plugin/authentication/AuthenticationProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/authentication/AuthenticationProvider.java
@@ -12,7 +12,7 @@ public interface AuthenticationProvider {
      * Use this method to get the current authenticationInfo object.
      * This returns null if isAuthenticated returns false.
      */
-    AuthenticationInfo getAuthenticationInfo();
+    AuthenticationInfo getAuthenticationInfo(final String serverUri);
 
     /**
      * Use this method to initiate the background authentication.
@@ -24,11 +24,11 @@ public interface AuthenticationProvider {
     /**
      * Use this method to clear all authentication information and set isAuthenticated to false.
      */
-    void clearAuthenticationDetails();
+    void clearAuthenticationDetails(final String serverUri);
 
     /**
      * This method returns true if the Authentication has completed and was successful.
      */
-    boolean isAuthenticated();
+    boolean isAuthenticated(final String serverUri);
 
 }

--- a/plugin/src/com/microsoft/alm/plugin/authentication/facades/VsoAuthInfoProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/authentication/facades/VsoAuthInfoProvider.java
@@ -4,11 +4,8 @@
 package com.microsoft.alm.plugin.authentication.facades;
 
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.microsoft.alm.auth.PromptBehavior;
-import com.microsoft.alm.auth.oauth.AzureAuthority;
 import com.microsoft.alm.auth.oauth.OAuth2Authenticator;
 import com.microsoft.alm.auth.pat.VstsPatAuthenticator;
 import com.microsoft.alm.common.utils.UrlHelper;
@@ -16,10 +13,11 @@ import com.microsoft.alm.helpers.Action;
 import com.microsoft.alm.oauth2.useragent.AuthorizationException;
 import com.microsoft.alm.plugin.authentication.AuthHelper;
 import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
+import com.microsoft.alm.plugin.authentication.AuthenticationInfo.CredsType;
+import com.microsoft.alm.plugin.context.RestClientHelper;
 import com.microsoft.alm.plugin.exceptions.ProfileDoesNotExistException;
 import com.microsoft.alm.plugin.services.DeviceFlowResponsePrompt;
 import com.microsoft.alm.plugin.services.PluginServiceProvider;
-import com.microsoft.alm.provider.JaxrsClientProvider;
 import com.microsoft.alm.secret.Token;
 import com.microsoft.alm.secret.TokenPair;
 import com.microsoft.alm.secret.VsoTokenScope;
@@ -34,8 +32,6 @@ import javax.ws.rs.client.Client;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.Executors;
 
 public class VsoAuthInfoProvider implements AuthenticationInfoProvider {
     private final static Logger logger = LoggerFactory.getLogger(VsoAuthInfoProvider.class);
@@ -43,7 +39,6 @@ public class VsoAuthInfoProvider implements AuthenticationInfoProvider {
     private static final String CLIENT_ID = "97877f11-0fc6-4aee-b1ff-febb0519dd00";
     private static final String REDIRECT_URL = "https://java.visualstudio.com";
 
-    private final ListeningExecutorService executorService;
     private final SecretStore<TokenPair> accessTokenStore;
     private final SecretStore<Token> tokenStore;
     private final DeviceFlowResponsePrompt deviceFlowResponsePrompt;
@@ -52,9 +47,6 @@ public class VsoAuthInfoProvider implements AuthenticationInfoProvider {
     private VsoAuthInfoProvider() {
         accessTokenStore = new InsecureInMemoryStore<TokenPair>();
         tokenStore = new InsecureInMemoryStore<Token>();
-
-        //Only allow 5 threads to start polling
-        executorService = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(5));
 
         deviceFlowResponsePrompt = PluginServiceProvider.getInstance().getDeviceFlowResponsePrompt();
 
@@ -70,7 +62,7 @@ public class VsoAuthInfoProvider implements AuthenticationInfoProvider {
     }
 
     @Override
-    public void getAuthenticationInfoAsync(final String serverUri, final AuthenticationInfoCallback callback) {
+    public void getAuthenticationInfoAsync(String serverUri, final AuthenticationInfoCallback callback) {
         final SettableFuture<AuthenticationInfo> authenticationInfoFuture = SettableFuture.<AuthenticationInfo>create();
 
         // Callback for the Device Flow dialog to cancel the current authenticating process.
@@ -84,68 +76,23 @@ public class VsoAuthInfoProvider implements AuthenticationInfoProvider {
         };
 
         // Must share the same accessTokenStore with the member variable vstsPatAuthenticator to avoid prompt the user
-        // when we generate PAT
+        // when we generate PersonalAccessToken
         final OAuth2Authenticator.OAuth2AuthenticatorBuilder oAuth2AuthenticatorBuilder = new OAuth2Authenticator.OAuth2AuthenticatorBuilder()
                 .withClientId(CLIENT_ID)
                 .redirectTo(REDIRECT_URL)
                 .backedBy(accessTokenStore)
+                .manage(OAuth2Authenticator.MANAGEMENT_CORE_RESOURCE)
                 .withDeviceFlowCallback(deviceFlowResponsePrompt.getCallback(cancellationCallback));
-
-        // Check if common url was passed or if a specific url was given
-        // If a specific url is being used and a tenant id is found use the tenant id with the authenticator
-        String resourceId = OAuth2Authenticator.MANAGEMENT_CORE_RESOURCE;
-        final URI encodedServerUri = UrlHelper.createUri(serverUri);
-        if (!OAuth2Authenticator.APP_VSSPS_VISUALSTUDIO.getAuthority().equals(encodedServerUri.getAuthority())) {
-            try {
-                final UUID tenantId = AzureAuthority.detectTenantId(encodedServerUri);
-                if (tenantId != null) {
-                    logger.info(String.format("Adding tenant id %s to oAuth2Authenticator builder for url %s",
-                            tenantId.toString(), serverUri));
-                    resourceId = OAuth2Authenticator.VSTS_RESOURCE;
-                    oAuth2AuthenticatorBuilder.withTenantId(tenantId);
-                }
-            } catch (Error e) {
-                logger.warn("Error while trying to get tenant id", e);
-                // ok to continue without using tenant id
-            }
-        }
-        oAuth2AuthenticatorBuilder.manage(resourceId);
-
         final OAuth2Authenticator oAuth2Authenticator = oAuth2AuthenticatorBuilder.build();
-        final JaxrsClientProvider jaxrsClientProvider = new JaxrsClientProvider(oAuth2Authenticator);
+
+        final URI encodedServerUri = UrlHelper.createUri(serverUri);
+        final TokenPair tokenPair = oAuth2Authenticator.getOAuth2TokenPair(encodedServerUri, PromptBehavior.AUTO);
 
         try {
             AuthenticationInfo authenticationInfo = null;
             String errorMessage = null;
-            final Client client = jaxrsClientProvider.getClient();
 
-            if (client != null) {
-                //Or we could reconsider the name of the token.  Now we call Profile endpoint just to get the email address
-                //which is used in token description, but do we need it?  User can only view PATs after they login, and
-                //at that time user knows which account/email they are logged in under already.  So the email provides
-                //no additional value.
-                final AccountHttpClient accountHttpClient
-                        = new MyHttpClient(client, OAuth2Authenticator.APP_VSSPS_VISUALSTUDIO);
-
-                final Profile me = accountHttpClient.getMyProfile();
-                final String emailAddress = me.getCoreAttributes().getEmailAddress().getValue();
-
-                final String tokenDescription = AuthHelper.getTokenDescription(emailAddress);
-
-                final Token token = vstsPatAuthenticator.getPersonalAccessToken(
-                        VsoTokenScope.AllScopes,
-                        tokenDescription,
-                        PromptBehavior.AUTO);
-
-                if (token != null) {
-                    authenticationInfo = new AuthenticationInfo(me.getId().toString(),
-                            token.Value, serverUri, emailAddress);
-                } else {
-                    errorMessage = "Failed to get a Personal Access Token";
-                }
-            } else {
-                errorMessage = "Failed to get authenticated jaxrs client.";
-            }
+            authenticationInfo = getAuthenticationInfo(encodedServerUri, tokenPair);
 
             if (authenticationInfo != null) {
                 authenticationInfoFuture.set(authenticationInfo);
@@ -160,10 +107,62 @@ public class VsoAuthInfoProvider implements AuthenticationInfoProvider {
         Futures.addCallback(authenticationInfoFuture, callback);
     }
 
+    public AuthenticationInfo getAuthenticationInfo(final URI serverUri, final TokenPair tokenPair) {
+
+        if (tokenPair != null) {
+            final Client client = RestClientHelper.getClient(serverUri.toString(), tokenPair.AccessToken.Value);
+
+            if (client != null) {
+                //Or we could reconsider the name of the token.  Now we call Profile endpoint just to get the email address
+                //which is used in token description, but do we need it?  User can only view PATs after they login, and
+                //at that time user knows which account/email they are logged in under already.  So the email provides
+                //no additional value.
+                final AccountHttpClient accountHttpClient
+                        = new MyHttpClient(client, OAuth2Authenticator.APP_VSSPS_VISUALSTUDIO);
+
+                final Profile me = accountHttpClient.getMyProfile();
+                final String emailAddress = me.getCoreAttributes().getEmailAddress().getValue();
+                final String tokenDescription = AuthHelper.getTokenDescription(emailAddress);
+
+                if (serverUri.equals(OAuth2Authenticator.APP_VSSPS_VISUALSTUDIO)) {
+                    return new AuthenticationInfo (
+                            me.getId().toString(),
+                            tokenPair.AccessToken.Value,
+                            serverUri.toString(),
+                            emailAddress,
+                            CredsType.AccessToken,
+                            tokenPair.RefreshToken.Value);
+                } else {
+                    final Token token = vstsPatAuthenticator.getPersonalAccessToken(
+                            serverUri,
+                            VsoTokenScope.AllScopes,
+                            tokenDescription,
+                            PromptBehavior.AUTO,
+                            tokenPair);
+
+                    if (token != null) {
+                        return new AuthenticationInfo(
+                                me.getId().toString(),
+                                token.Value,
+                                serverUri.toString(),
+                                emailAddress,
+                                CredsType.PersonalAccessToken,
+                                null);
+                    } else {
+                        logger.warn("Failed to get a Personal Access Token");
+                    }
+                }
+            }
+        } else {
+            logger.warn("Failed to get authenticated jaxrs client.");
+        }
+
+        return null;
+    }
+
     @Override
     public void clearAuthenticationInfo(final String serverUri) {
-        // Only generates global PAT currently, so ignore serverUri and clear global PAT only
-        this.vstsPatAuthenticator.signOut();
+        this.vstsPatAuthenticator.signOut(URI.create(serverUri));
     }
 
     // We are subclassing the AccountHttpClient here in order to add mapped exceptions

--- a/plugin/src/com/microsoft/alm/plugin/context/RestClientHelper.java
+++ b/plugin/src/com/microsoft/alm/plugin/context/RestClientHelper.java
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.plugin.context;
+
+import com.microsoft.alm.plugin.authentication.AuthHelper;
+import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
+import com.microsoft.alm.plugin.context.ServerContext;
+import com.microsoft.alm.plugin.services.HttpProxyService;
+import com.microsoft.alm.plugin.services.PluginServiceProvider;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.VersionInfo;
+import org.glassfish.jersey.SslConfigurator;
+import org.glassfish.jersey.apache.connector.ApacheClientProperties;
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.RequestEntityProcessing;
+import org.glassfish.jersey.client.spi.ConnectorProvider;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+
+/**
+ * JAXRS Rest Client helper
+ */
+public class RestClientHelper {
+
+    public static Client getClient(final String serverUri, final String accessTokenValue) {
+        final Credentials credentials = new UsernamePasswordCredentials("accessToken", accessTokenValue);
+        final ClientConfig clientConfig = getClientConfig(ServerContext.Type.VSO_DEPLOYMENT, credentials, serverUri,
+                PluginServiceProvider.getInstance().getHttpProxyService().useHttpProxy());
+
+        final Client localClient = ClientBuilder.newClient(clientConfig);
+        return localClient;
+    }
+
+    public static Client getClient(final ServerContext.Type type, final AuthenticationInfo authenticationInfo) {
+        final ClientConfig clientConfig = getClientConfig(type, authenticationInfo,
+                PluginServiceProvider.getInstance().getHttpProxyService().useHttpProxy());
+        final Client localClient = ClientBuilder.newClient(clientConfig);
+        return localClient;
+    }
+
+    public static ClientConfig getClientConfig(final ServerContext.Type type,
+                                               final Credentials credentials,
+                                               final String serverUri,
+                                               final boolean includeProxySettings) {
+
+        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY, credentials);
+
+        final ConnectorProvider connectorProvider = new ApacheConnectorProvider();
+
+        final ClientConfig clientConfig = new ClientConfig().connectorProvider(connectorProvider);
+        clientConfig.property(ApacheClientProperties.CREDENTIALS_PROVIDER, credentialsProvider);
+        clientConfig.property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.BUFFERED);
+
+        // For TFS OnPrem we only support NTLM authentication right now. Since 2016 servers support Basic as well,
+        // we need to let the server and client negotiate the protocol instead of preemptively assuming Basic.
+        // TODO: This prevents PATs from being used OnPrem. We need to fix this soon to support PATs onPrem.
+        clientConfig.property(ApacheClientProperties.PREEMPTIVE_BASIC_AUTHENTICATION, type != ServerContext.Type.TFS);
+
+        //Define a local HTTP proxy
+        if (includeProxySettings) {
+            final HttpProxyService proxyService = PluginServiceProvider.getInstance().getHttpProxyService();
+            final String proxyUrl = proxyService.getProxyURL();
+            clientConfig.property(ClientProperties.PROXY_URI, proxyUrl);
+            if (proxyService.isAuthenticationRequired()) {
+                // To work with authenticated proxies and TFS, we provide the proxy credentials if they are registered
+                final AuthScope ntlmAuthScope =
+                        new AuthScope(proxyService.getProxyHost(), proxyService.getProxyPort(),
+                                AuthScope.ANY_REALM, AuthScope.ANY_SCHEME);
+                credentialsProvider.setCredentials(ntlmAuthScope,
+                        new UsernamePasswordCredentials(proxyService.getUserName(), proxyService.getPassword()));
+            }
+        }
+
+        // if this is a onPrem server and the uri starts with https, we need to setup ssl
+        if (isSSLEnabledOnPrem(type, serverUri)) {
+            clientConfig.property(ApacheClientProperties.SSL_CONFIG, getSslConfigurator());
+        }
+
+        // register a filter to set the User Agent header
+        clientConfig.register(new ClientRequestFilter() {
+            @Override
+            public void filter(final ClientRequestContext requestContext) throws IOException {
+                // The default user agent is something like "Jersey/2.6"
+                final String defaultUserAgent = VersionInfo.getUserAgent("Apache-HttpClient", "org.apache.http.client", HttpClientBuilder.class);
+                // We get the user agent string from the Telemetry context
+                final String userAgent = PluginServiceProvider.getInstance().getTelemetryContextInitializer().getUserAgent(defaultUserAgent);
+                // Finally, we can add the header
+                requestContext.getHeaders().add(HttpHeaders.USER_AGENT, userAgent);
+            }
+        });
+
+        return clientConfig;
+    }
+
+    public static ClientConfig getClientConfig(final ServerContext.Type type,
+                                               final AuthenticationInfo authenticationInfo,
+                                               final boolean includeProxySettings) {
+        final Credentials credentials = AuthHelper.getCredentials(type, authenticationInfo);
+
+        return getClientConfig(type, credentials, authenticationInfo.getServerUri(), includeProxySettings);
+    }
+
+    public static boolean isSSLEnabledOnPrem(final ServerContext.Type type, final String serverUri) {
+        return type == ServerContext.Type.TFS && serverUri.toLowerCase().startsWith("https://");
+    }
+
+    public static SslConfigurator getSslConfigurator() {
+        /**
+         * Set up trust store and key store for the https connection.
+         *
+         * http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html
+         * See table 6.
+         */
+        final SslConfigurator sslConfigurator = SslConfigurator.newInstance();
+
+        // Trust stores are used to store CA certificates. It is used to trust the server connection.
+        setupTrustStore(sslConfigurator);
+
+        // Key stores are used to store client certificates.  It is used to authenticate the client.
+        setupKeyStore(sslConfigurator);
+
+        return sslConfigurator;
+    }
+
+    private static SslConfigurator setupTrustStore(final SslConfigurator sslConfigurator) {
+        // Create trust store from .cer
+        // keytool.exe  -import -trustcacerts -alias root -file cacert.cer -keystore truststore.jks
+        final String trustStore = System.getProperty("javax.net.ssl.trustStore");
+        final String trustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword", StringUtils.EMPTY);
+
+        final String trustStoreType = System.getProperty("javax.net.ssl.trustStoreType", "JKS");
+        final String trustManagerFactoryAlgorithm = System.getProperty("ssl.TrustManagerFactory.algorithm", "PKIX");
+
+        if (trustStore != null) {
+            sslConfigurator
+                    .trustStoreFile(trustStore)
+                    .trustStorePassword(trustStorePassword)
+                    .trustStoreType(trustStoreType)
+                    .trustManagerFactoryAlgorithm(trustManagerFactoryAlgorithm)
+                    .securityProtocol("SSL");
+        }
+
+        return sslConfigurator;
+    }
+
+    private static SslConfigurator setupKeyStore(final SslConfigurator sslConfigurator) {
+        // Create keystore from pkx:
+        // keytool -importkeystore -srckeystore mycert.pfx -srcstoretype pkcs12 -destkeystore keystore.jks -deststoretype JKS
+        final String keyStore = System.getProperty("javax.net.ssl.keyStore");
+        final String keyStorePassword = System.getProperty("javax.net.ssl.keyStorePassword", StringUtils.EMPTY);
+
+        if (keyStore != null) {
+            sslConfigurator
+                    .keyStoreFile(keyStore)
+                    .keyStorePassword(keyStorePassword);
+        }
+
+        return sslConfigurator;
+    }
+}

--- a/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java
+++ b/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.alm.plugin.context;
 
+import com.microsoft.alm.client.utils.StringUtil;
 import com.microsoft.alm.common.utils.ArgumentHelper;
 import com.microsoft.alm.common.utils.UrlHelper;
 import com.microsoft.alm.core.webapi.CoreHttpClient;
@@ -118,11 +119,26 @@ public class ServerContextManager {
         if (context != null) {
             final String key = context.getKey();
             contextMap.put(key, context);
-            getStore().saveServerContext(context);
+            // Only persist PATs, not access tokens
+            if (shouldBeSaved(context)) {
+                getStore().saveServerContext(context);
+            }
             if (updateLastUsedContext) {
                 setLastUsedContextKey(key);
             }
         }
+    }
+
+    private boolean shouldBeSaved(final ServerContext context) {
+        boolean result = true;
+        if (context != null && context.getAuthenticationInfo() != null) {
+            // do not save access tokens
+            if (AuthenticationInfo.CredsType.AccessToken.equals(context.getAuthenticationInfo().getType())) {
+                result = false;
+            }
+        }
+
+        return result;
     }
 
     public synchronized ServerContext get(final String uri) {
@@ -314,7 +330,7 @@ public class ServerContextManager {
      */
     public ServerContext getAuthenticatedContext(final String gitRemoteUrl, final boolean setAsActiveContext) {
         try {
-            // get context from builder, create PAT if needed, and store in active context
+            // get context from builder, create PersonalAccessToken if needed, and store in active context
             final ServerContext context = createContextFromGitRemoteUrl(gitRemoteUrl);
             if (context != null && setAsActiveContext) {
                 //nothing to do
@@ -581,6 +597,7 @@ public class ServerContextManager {
                     logger.info("auth info updateAuthenticationInfo prompting");
                     //prompt user
                     final AuthenticationProvider authenticationProvider = getAuthenticationProvider(remoteUrl);
+                    authenticationProvider.clearAuthenticationDetails(context.getServerUri().toString());
                     newAuthenticationInfo = AuthHelper.getAuthenticationInfoSynchronously(authenticationProvider, remoteUrl);
                     promptUser = false;
                 }

--- a/plugin/src/com/microsoft/alm/plugin/operations/AccountLookupOperation.java
+++ b/plugin/src/com/microsoft/alm/plugin/operations/AccountLookupOperation.java
@@ -26,8 +26,6 @@ import java.util.concurrent.Future;
 public class AccountLookupOperation extends Operation {
     private static final Logger logger = LoggerFactory.getLogger(AccountLookupOperation.class);
 
-    private Future innerOperation;
-
     public static class AccountLookupResults extends ResultsImpl {
         private final List<ServerContext> serverContexts = new ArrayList<ServerContext>();
 
@@ -52,7 +50,7 @@ public class AccountLookupOperation extends Operation {
             }
 
             final ServerContext vsoDeploymentContext = ServerContextManager.getInstance().get(VsoAuthenticationProvider.VSO_AUTH_URL);
-            if (!VsoAuthenticationProvider.getInstance().isAuthenticated() ||
+            if (!VsoAuthenticationProvider.getInstance().isAuthenticated(VsoAuthenticationProvider.VSO_AUTH_URL) ||
                     vsoDeploymentContext == null || vsoDeploymentContext.getType() == ServerContext.Type.TFS) {
                 // We aren't authenticated, or we couldn't find the VSO context
                 logger.warn("doWork unexpected server context, expected type VSO or VSO_DEPLOYMENT. Found: {}", vsoDeploymentContext);
@@ -67,7 +65,7 @@ public class AccountLookupOperation extends Operation {
                 final ServerContext accountContext =
                         new ServerContextBuilder().type(ServerContext.Type.VSO)
                                 .accountUri(a)
-                                .authentication(VsoAuthenticationProvider.getInstance().getAuthenticationInfo())
+                                .authentication(VsoAuthenticationProvider.getInstance().getAuthenticationInfo(VsoAuthenticationProvider.VSO_AUTH_URL))
                                 .userId(vsoDeploymentContext.getUserId())
                                 .build();
                 results.serverContexts.add(accountContext);
@@ -92,10 +90,6 @@ public class AccountLookupOperation extends Operation {
     @Override
     public void cancel() {
         super.cancel();
-
-        if (innerOperation != null && !innerOperation.isDone()) {
-            innerOperation.cancel(true);
-        }
 
         final AccountLookupResults results = new AccountLookupResults();
         results.isCancelled = true;

--- a/plugin/test/com/microsoft/alm/plugin/authentication/AuthHelperTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/authentication/AuthHelperTest.java
@@ -11,6 +11,8 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static com.microsoft.alm.plugin.authentication.AuthenticationInfo.CredsType.NTLM;
+
 public class AuthHelperTest {
     @Test
     public void getCredentials() {
@@ -49,7 +51,7 @@ public class AuthHelperTest {
     @Test
     public void createAuthInfo() {
         final Credentials credentials = new UsernamePasswordCredentials("userName", "password");
-        final AuthenticationInfo info = AuthHelper.createAuthenticationInfo("server", credentials);
+        final AuthenticationInfo info = AuthHelper.createAuthenticationInfo("server", credentials, NTLM);
         Assert.assertEquals("userName", info.getUserName());
         Assert.assertEquals("password", info.getPassword());
         Assert.assertEquals("server", info.getServerUri());

--- a/plugin/test/com/microsoft/alm/plugin/authentication/TfsAuthenticationProviderTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/authentication/TfsAuthenticationProviderTest.java
@@ -23,8 +23,8 @@ public class TfsAuthenticationProviderTest extends AbstractTest {
                 .uri(TfsAuthenticationProvider.TFS_LAST_USED_URL).authentication(info).build();
         ServerContextManager.getInstance().add(tfsContext);
         final TfsAuthenticationProvider provider = TfsAuthenticationProvider.getInstance();
-        Assert.assertEquals(info, provider.getAuthenticationInfo());
-        Assert.assertTrue(provider.isAuthenticated());
+        Assert.assertEquals(info, provider.getAuthenticationInfo(TfsAuthenticationProvider.TFS_LAST_USED_URL));
+        Assert.assertTrue(provider.isAuthenticated(TfsAuthenticationProvider.TFS_LAST_USED_URL));
     }
 
     @Test
@@ -34,11 +34,11 @@ public class TfsAuthenticationProviderTest extends AbstractTest {
                 .uri(TfsAuthenticationProvider.TFS_LAST_USED_URL).authentication(info).build();
         ServerContextManager.getInstance().add(tfsContext);
         final TfsAuthenticationProvider provider = TfsAuthenticationProvider.getInstance();
-        Assert.assertEquals(info, provider.getAuthenticationInfo());
-        Assert.assertTrue(provider.isAuthenticated());
-        provider.clearAuthenticationDetails();
-        Assert.assertEquals(null, provider.getAuthenticationInfo());
-        Assert.assertFalse(provider.isAuthenticated());
+        Assert.assertEquals(info, provider.getAuthenticationInfo(TfsAuthenticationProvider.TFS_LAST_USED_URL));
+        Assert.assertTrue(provider.isAuthenticated(TfsAuthenticationProvider.TFS_LAST_USED_URL));
+        provider.clearAuthenticationDetails(TfsAuthenticationProvider.TFS_LAST_USED_URL);
+        Assert.assertEquals(null, provider.getAuthenticationInfo(TfsAuthenticationProvider.TFS_LAST_USED_URL));
+        Assert.assertFalse(provider.isAuthenticated(TfsAuthenticationProvider.TFS_LAST_USED_URL));
     }
 
     @Test

--- a/plugin/test/com/microsoft/alm/plugin/context/ServerContextTest.java
+++ b/plugin/test/com/microsoft/alm/plugin/context/ServerContextTest.java
@@ -92,7 +92,7 @@ public class ServerContextTest extends AbstractTest {
     @Test
     public void getClientConfig() {
         AuthenticationInfo info = new AuthenticationInfo("user1", "pass", "server1", "4display");
-        final ClientConfig config = ServerContext.getClientConfig(ServerContext.Type.TFS, info, false);
+        final ClientConfig config = RestClientHelper.getClientConfig(ServerContext.Type.TFS, info, false);
 
         final Map<String, Object> properties = config.getProperties();
         Assert.assertEquals(3, properties.size());
@@ -106,7 +106,7 @@ public class ServerContextTest extends AbstractTest {
         Assert.assertEquals(info.getUserName(), credentials.getUserPrincipal().getName());
 
         // Make sure Fiddler properties get set if property is on
-        final ClientConfig config2 = ServerContext.getClientConfig(ServerContext.Type.TFS, info, true);
+        final ClientConfig config2 = RestClientHelper.getClientConfig(ServerContext.Type.TFS, info, true);
         final Map<String, Object> properties2 = config2.getProperties();
         //proxy setting doesn't automatically mean we need to setup ssl trust store anymore
         Assert.assertEquals(4, properties2.size());
@@ -114,7 +114,7 @@ public class ServerContextTest extends AbstractTest {
         Assert.assertNull(properties2.get(ApacheClientProperties.SSL_CONFIG));
 
         info = new AuthenticationInfo("users1", "pass", "https://tfsonprem.test", "4display");
-        final ClientConfig config3 = ServerContext.getClientConfig(ServerContext.Type.TFS, info, false);
+        final ClientConfig config3 = RestClientHelper.getClientConfig(ServerContext.Type.TFS, info, false);
         final Map<String, Object> properties3 = config3.getProperties();
         Assert.assertEquals(4, properties3.size());
         Assert.assertNull(properties3.get(ClientProperties.PROXY_URI));

--- a/plugin/test/com/microsoft/alm/plugin/mocks/MockVsoAuthenticationProvider.java
+++ b/plugin/test/com/microsoft/alm/plugin/mocks/MockVsoAuthenticationProvider.java
@@ -15,7 +15,7 @@ public class MockVsoAuthenticationProvider extends VsoAuthenticationProvider {
     }
 
     @Override
-    public AuthenticationInfo getAuthenticationInfo() {
+    public AuthenticationInfo getAuthenticationInfo(final String serverUri) {
         return authenticationInfo;
     }
 
@@ -28,12 +28,12 @@ public class MockVsoAuthenticationProvider extends VsoAuthenticationProvider {
     }
 
     @Override
-    public void clearAuthenticationDetails() {
+    public void clearAuthenticationDetails(final String serverUri) {
         authenticationInfo = null;
     }
 
     @Override
-    public boolean isAuthenticated() {
+    public boolean isAuthenticated(final String serverUri) {
         return authenticationInfo != null;
     }
 }


### PR DESCRIPTION
Removed global PATs.  Now the plugin will create account level PATs only when we connect to specific accounts.  Otherwise plugin will generate an AAD Access Token and use that for browsing.

Also need to pass around the specific server url to generate tenant specific access token, this is to make mseng work.  