### PR TITLE
Update vsts-ci.yml

### DIFF
--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -1,11 +1,9 @@
 resources:
-- repo: self
-  clean: true
+- clean: true
 queue:
   name: Java
   condition: succeeded()
   demands: java
-
 
 steps:
 - task: CmdLine@1


### PR DESCRIPTION
Remove the `repo: self` bit from the definition, as self-referencing build definitions cause CI heartburn (sorry!).