### PR TITLE
build: restore missing task to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,10 @@ project(":plugin.idea") {
     task showVersion() {
         println("version = " + buildNumber)
     }
+    
+    task delTestTelemetryPropFile << {
+        delete 'resources/telemetry/com.microsoft.alm.plugin-telemetry.properties'
+    }
 
     task zip(dependsOn: ['buildPlugin','test']) {}
 }


### PR DESCRIPTION
To suppor the release build, we need all of the tasks used to exist.