### PR TITLE
Support VSTS Organizations

### DIFF
--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/common/ui/common/LoginPageModelImpl.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/common/ui/common/LoginPageModelImpl.java
@@ -124,10 +124,11 @@ public abstract class LoginPageModelImpl extends AbstractModel implements LoginP
                 // no slash, not "Microsoft Account" and does not contain visualstudio.com or tfsallin.net
                 // means it must just be a on-premise TFS server name, so add all the normal stuff
                 newServerName = String.format(DEFAULT_SERVER_FORMAT, serverName);
-            } else if (!StringUtils.contains(serverName, UrlHelper.URL_SEPARATOR)
-                    && (StringUtils.containsIgnoreCase(serverName, UrlHelper.HOST_VSO) || StringUtils.containsIgnoreCase(serverName, UrlHelper.HOST_TFS_ALL_IN))) {
-                //no slash and contains visualstudio.com or tfsallin.net
-                // means it must be a VSTS account
+            } else if ((!StringUtils.contains(serverName, UrlHelper.URL_SEPARATOR)
+                    && (StringUtils.containsIgnoreCase(serverName, UrlHelper.HOST_VSO) ||
+                        StringUtils.containsIgnoreCase(serverName, UrlHelper.HOST_TFS_ALL_IN))) ||
+                    (UrlHelper.isOrganizationUrl(String.format(DEFAULT_VSTS_ACCOUNT_FORMAT, serverName)) )) {
+                // add "https://" to VSTS accounts if it isn't provided
                 newServerName = String.format(DEFAULT_VSTS_ACCOUNT_FORMAT, serverName);
             } else {
                 newServerName = serverName;

--- a/plugin.idea/src/com/microsoft/alm/plugin/idea/common/ui/common/ServerContextTableModel.java
+++ b/plugin.idea/src/com/microsoft/alm/plugin/idea/common/ui/common/ServerContextTableModel.java
@@ -4,6 +4,7 @@
 package com.microsoft.alm.plugin.idea.common.ui.common;
 
 
+import com.microsoft.alm.common.utils.UrlHelper;
 import com.microsoft.alm.core.webapi.model.TeamProjectCollectionReference;
 import com.microsoft.alm.core.webapi.model.TeamProjectReference;
 import com.microsoft.alm.plugin.context.ServerContext;
@@ -216,7 +217,9 @@ public class ServerContextTableModel extends AbstractTableModel {
                 return collection != null ? collection.getName() : "";
             }
             case ACCOUNT:
-                return serverContext.getUri().getHost();
+                return UrlHelper.isOrganizationURI(serverContext.getUri())
+                        ? serverContext.getUri().getHost() + "/" + serverContext.getTeamProjectCollectionReference().getName()
+                        : serverContext.getUri().getHost();
             case GENERAL_REPOSITORY: {
                 if (serverContext.getGitRepository() != null) {
                     return serverContext.getGitRepository().getName();

--- a/plugin.idea/test/com/microsoft/alm/plugin/idea/common/ui/common/LoginPageModelTest.java
+++ b/plugin.idea/test/com/microsoft/alm/plugin/idea/common/ui/common/LoginPageModelTest.java
@@ -44,5 +44,21 @@ public class LoginPageModelTest extends AbstractTest {
         //full url
         underTest.setServerName("https://myserver:8080/tfs/virtualpath");
         assertEquals("https://myserver:8080/tfs/virtualpath", underTest.getServerName());
+
+        //Azure url
+        underTest.setServerName("azure.com/account");
+        assertEquals("https://azure.com/account", underTest.getServerName());
+
+        //Azure org url
+        underTest.setServerName("org.azure.com/account");
+        assertEquals("https://org.azure.com/account", underTest.getServerName());
+
+        //Azure full url
+        underTest.setServerName("https://azure.com/account");
+        assertEquals("https://azure.com/account", underTest.getServerName());
+
+        //Azure org full url
+        underTest.setServerName("https://org.azure.com/account");
+        assertEquals("https://org.azure.com/account", underTest.getServerName());
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/context/ServerContextBuilder.java
+++ b/plugin/src/com/microsoft/alm/plugin/context/ServerContextBuilder.java
@@ -9,7 +9,6 @@ import com.microsoft.alm.plugin.authentication.AuthenticationInfo;
 import com.microsoft.alm.core.webapi.model.TeamProjectCollectionReference;
 import com.microsoft.alm.core.webapi.model.TeamProjectReference;
 import com.microsoft.alm.sourcecontrol.webapi.model.GitRepository;
-import com.microsoft.visualstudio.services.account.Account;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,8 +80,8 @@ public class ServerContextBuilder {
         return this;
     }
 
-    public ServerContextBuilder accountUri(final Account account) {
-        this.uri = UrlHelper.getVSOAccountURI(account.getAccountName());
+    public ServerContextBuilder accountUri(final String accountUri) {
+        this.uri = UrlHelper.createUri(accountUri);
         this.serverUri = this.uri;
         return this;
     }

--- a/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java
+++ b/plugin/src/com/microsoft/alm/plugin/context/ServerContextManager.java
@@ -475,7 +475,7 @@ public class ServerContextManager {
         // For now I will just do a linear search for an appropriate context info to copy the auth info from
         final URI remoteUri = UrlHelper.createUri(gitRemoteUrl);
         for (final ServerContext context : getAllServerContexts()) {
-            if (UrlHelper.haveSameAuthority(remoteUri, context.getUri())) {
+            if (UrlHelper.haveSameAccount(remoteUri, context.getUri())) {
                 logger.info("AuthenticatedInfo found for url " + gitRemoteUrl);
                 authenticationInfo = context.getAuthenticationInfo();
                 break;
@@ -589,7 +589,7 @@ public class ServerContextManager {
         //Linear search through all contexts to find the ones with same authority as remoteUrl
         for (final ServerContext context : getAllServerContexts()) {
             logger.info("auth info updateAuthenticationInfo compare " + context.getUri().getPath());
-            if (UrlHelper.haveSameAuthority(remoteUri, context.getUri())) {
+            if (UrlHelper.haveSameAccount(remoteUri, context.getUri())) {
                 //remove the context with old credentials
                 remove(context.getKey());
 
@@ -747,6 +747,9 @@ public class ServerContextManager {
                 }
 
                 serverUrl = vstsInfo.getServerUrl();
+                if (UrlHelper.isOrganizationUrl(serverUrl)) {
+                    serverUrl = serverUrl + "/" + UrlHelper.getAccountFromOrganization(vstsInfo.getRepository().getRemoteUrl());
+                }
 
                 collection = new TeamProjectCollection();
                 collection.setId(vstsInfo.getCollectionReference().getId());
@@ -779,14 +782,21 @@ public class ServerContextManager {
                 final String collectionName;
                 final String serverUrl;
                 if (UrlHelper.isTeamServicesUrl(collectionUrl)) {
-                    // The Team Services collection is ALWAYS defaultCollection, and both the url with defaultcollection
-                    // and the url without defaultCollection will validate just fine. However, it expects you to refer to
-                    // the collection by the account name. So, we just need to grab the account name and use that to
-                    // recreate the url.
-                    // If validation fails, we return false.
-                    final String accountName = UrlHelper.getVSOAccountName(UrlHelper.createUri(collectionUrl));
-                    serverUrl = UrlHelper.getVSOAccountURI(accountName).toString();
-                    collectionName = accountName;
+                    if (UrlHelper.isOrganizationUrl(collectionUrl)) {
+                        // For organizations the serverUrl == the collectionUrl
+                        serverUrl = collectionUrl;
+                        // Collection name is the account, i.e. azure.com/account
+                        collectionName = UrlHelper.getAccountFromOrganization(serverUrl);
+                    } else {
+                        // The Team Services collection is ALWAYS defaultCollection, and both the url with defaultcollection
+                        // and the url without defaultCollection will validate just fine. However, it expects you to refer to
+                        // the collection by the account name. So, we just need to grab the account name and use that to
+                        // recreate the url.
+                        // If validation fails, we return false.
+                        final String accountName = UrlHelper.getVSOAccountName(UrlHelper.createUri(collectionUrl));
+                        serverUrl = UrlHelper.getVSOAccountURI(accountName).toString();
+                        collectionName = accountName;
+                    }
                     if (!validateTfvcCollectionUrl(serverUrl)) {
                         return false;
                     }

--- a/plugin/src/com/microsoft/alm/plugin/operations/AccountLookupOperation.java
+++ b/plugin/src/com/microsoft/alm/plugin/operations/AccountLookupOperation.java
@@ -3,27 +3,37 @@
 
 package com.microsoft.alm.plugin.operations;
 
-import com.microsoft.alm.common.utils.UrlHelper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.alm.plugin.authentication.AuthHelper;
 import com.microsoft.alm.plugin.authentication.VsoAuthenticationProvider;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.context.ServerContextBuilder;
 import com.microsoft.alm.plugin.context.ServerContextManager;
 import com.microsoft.alm.plugin.exceptions.TeamServicesException;
-import com.microsoft.visualstudio.services.account.Account;
-import com.microsoft.visualstudio.services.account.AccountHttpClient;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Use this operation class to lookup the accounts on VSO for a particular user.
  */
 public class AccountLookupOperation extends Operation {
     private static final Logger logger = LoggerFactory.getLogger(AccountLookupOperation.class);
+
+    private static final String ACCOUNT_ENDPOINT = "/_apis/Accounts?memberid=%s&api-version=1.0";
+    private static final String TFS_SERVICE_URL_PROPERTY_NAME = "Microsoft.VisualStudio.Services.Account.ServiceUrl.00025394-6065-48CA-87D9-7F5672854EF7";
 
     public static class AccountLookupResults extends ResultsImpl {
         private final List<ServerContext> serverContexts = new ArrayList<ServerContext>();
@@ -56,14 +66,16 @@ public class AccountLookupOperation extends Operation {
                 throw new TeamServicesException(TeamServicesException.KEY_VSO_AUTH_FAILED);
             }
 
-            final AccountHttpClient accountHttpClient = new AccountHttpClient(vsoDeploymentContext.getClient(),
-                    UrlHelper.createUri(VsoAuthenticationProvider.VSO_AUTH_URL));
-            List<Account> accounts = accountHttpClient.getAccounts(vsoDeploymentContext.getUserId());
+            //Get uris for the accounts the user has access to
+            final List<String> accountUris = this.getAccountUris(vsoDeploymentContext);
+            //Loop thru results and add them to the server context
             final AccountLookupResults results = new AccountLookupResults();
-            for (final Account a : accounts) {
+            for (final String accountUri : accountUris)
+            {
+                // Each account gets it's own context (i.e. azure.com/account1, azure.com/account2, etc..)
                 final ServerContext accountContext =
                         new ServerContextBuilder().type(ServerContext.Type.VSO)
-                                .accountUri(a)
+                                .accountUri(accountUri)
                                 .authentication(VsoAuthenticationProvider.getInstance().getAuthenticationInfo(VsoAuthenticationProvider.VSO_AUTH_URL))
                                 .userId(vsoDeploymentContext.getUserId())
                                 .build();
@@ -104,5 +116,41 @@ public class AccountLookupOperation extends Operation {
         results.error = throwable;
         onLookupResults(results);
         onLookupCompleted();
+    }
+
+    // Make a server call to get the uris for the accounts the user has access to
+    private List<String> getAccountUris(final ServerContext vsoDeploymentContext) {
+        // new list of account uris to return
+        List<String> accountUris = new ArrayList<String>();
+
+        // Issue account request
+        final Client accountClient = vsoDeploymentContext.getClient();
+        final String accountApiUrlFormat = VsoAuthenticationProvider.VSO_AUTH_URL + ACCOUNT_ENDPOINT;
+        final WebTarget resourceTarget = accountClient.target(String.format(accountApiUrlFormat, vsoDeploymentContext.getUserId()));
+        final Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("api-version", "3.0-preview.1");
+        parameters.put("charset", "UTF-8");
+        final Invocation invocation = resourceTarget.request(
+                new MediaType("application", "json", parameters))
+                .buildGet();
+        final String response = invocation.invoke(String.class);
+
+        // Parse result tree
+        final ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = null;
+        try {
+            rootNode = objectMapper.readTree(response);
+        } catch (IOException e) {
+            logger.error("Could not parse Account response", e);
+            return accountUris;
+        }
+
+        // Loop thru account results and add them to the list
+        final List<JsonNode> nodes = rootNode.findValues(TFS_SERVICE_URL_PROPERTY_NAME);
+        for (final JsonNode node : nodes)
+        {
+            accountUris.add(StringUtils.removeEnd(node.path("$value").asText(), "/"));
+        }
+        return accountUris;
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/operations/AccountLookupOperation.java
+++ b/plugin/src/com/microsoft/alm/plugin/operations/AccountLookupOperation.java
@@ -142,7 +142,7 @@ public class AccountLookupOperation extends Operation {
             rootNode = objectMapper.readTree(response);
         } catch (IOException e) {
             logger.error("Could not parse Account response", e);
-            return accountUris;
+            throw new TeamServicesException(TeamServicesException.KEY_VSO_AUTH_FAILED, e);
         }
 
         // Loop thru account results and add them to the list


### PR DESCRIPTION
This change adds support for reading organization from the VSTS host URL path.

 - [x] Add support for VSTS domain azure.com or {org}.azure.com this updates multiple area required for this change.
 - [x] Switched to using account URI rather than building URI manually from account.

_This work was mostly completed by @jeschu1 with some clean up work by me (you can still blame me for any problems it causes)._